### PR TITLE
Updates involving table filters

### DIFF
--- a/src/js/components/accordion/accordion.css
+++ b/src/js/components/accordion/accordion.css
@@ -1,10 +1,10 @@
 .summary-accordion {
-    width: 60%;
+    width: 70%;
     margin: auto;
 }
 
 .accordion-title {
-    margin-left: 20%;
+    margin-left: 15%;
     font-weight: bold;
     /* font-size: 20px; */
     padding-bottom: 10px;
@@ -79,5 +79,5 @@ span.top-line-amount {
     font-weight: bold;
     position: absolute;
     right: 0;
-    margin-right: calc(20vw + 20px);
+    margin-right: calc(15vw + 20px);
 }

--- a/src/js/components/accordion/accordion.js
+++ b/src/js/components/accordion/accordion.js
@@ -5,7 +5,7 @@ import {Baseline, CurrentFund, Fund, Supplemental, FundLookupTable} from '../../
 import { formatCurrency, cleanString } from "../../utils/common_utils.js";
 import Table from "../table/table.js";
 import { visitPage } from '../../views/view_logic.js';
-import { Appropriation } from '../../models/fund.js';
+import { Appropriation, CostCenter } from '../../models/fund.js';
 
 function redirectForEdit(){
     // action taken when user clicks on any of the edit buttons in the accordion
@@ -22,10 +22,10 @@ function redirectForEdit(){
         // record the fund
         CurrentFund.update(fund);
         // record the appropriation and cost center
-        let approp = new Appropriation(table.id.split('-')[2]);
-        console.log(approp.name());
+        let approp = new Appropriation(fund, table.id.split('-')[2]);
+        let cc = new CostCenter(fund, table.id.split('-')[2], table.id.split('-')[3]);
         localStorage.setItem('filter-approp-name', approp.name());
-        localStorage.setItem('filter-cc-name', table.id.split('-')[3]);
+        localStorage.setItem('filter-cc-name', cc.getName());
 
         // visit the correct page for editing
         const lineItem = row.querySelector('.line-item').textContent;

--- a/src/js/components/accordion/accordion.js
+++ b/src/js/components/accordion/accordion.js
@@ -5,6 +5,7 @@ import {Baseline, CurrentFund, Fund, Supplemental, FundLookupTable} from '../../
 import { formatCurrency, cleanString } from "../../utils/common_utils.js";
 import Table from "../table/table.js";
 import { visitPage } from '../../views/view_logic.js';
+import { Appropriation } from '../../models/fund.js';
 
 function redirectForEdit(){
     // action taken when user clicks on any of the edit buttons in the accordion
@@ -21,8 +22,10 @@ function redirectForEdit(){
         // record the fund
         CurrentFund.update(fund);
         // record the appropriation and cost center
-        localStorage.setItem('filter-approp', table.id.split('-')[2]);
-        localStorage.setItem('filter-cc', table.id.split('-')[3]);
+        let approp = new Appropriation(table.id.split('-')[2]);
+        console.log(approp.name());
+        localStorage.setItem('filter-approp-name', approp.name());
+        localStorage.setItem('filter-cc-name', table.id.split('-')[3]);
 
         // visit the correct page for editing
         const lineItem = row.querySelector('.line-item').textContent;

--- a/src/js/components/accordion/accordion.js
+++ b/src/js/components/accordion/accordion.js
@@ -66,8 +66,8 @@ const ExpenseTable = {
         this.createNewCell(formatCurrency(number), new_row, 'cost');
         // create Edit button 
         var button = '';
-        if (row_name != 'Net Expenditures (Revenues)'){
-            button = Table.Buttons.Edit.html;
+        if (row_name != 'Total Expenditures'){
+            button = Table.Buttons.Edit.html(`Edit in table`);
         }
         this.createNewCell(button, new_row);
     },
@@ -108,7 +108,7 @@ const ExpenseTable = {
         this.addRow(ccObj.accountString(), 'Overtime Expenditures', ccObj.getOvertimeCost());
         this.addRow(ccObj.accountString(), 'Non-Personnel Expenditures', ccObj.getNonPersonnelCost());
         this.addRow(ccObj.accountString(), 'Revenues', ccObj.getRevenue());
-        this.addRow(ccObj.accountString(), 'Net Expenditures (Revenues)', ccObj.getTotal());
+        this.addRow(ccObj.accountString(), 'Total Expenditures', ccObj.getTotal());
     },
     fillFromInit(program) {
         // Fill out info for each supplemental init

--- a/src/js/components/accordion/accordion.js
+++ b/src/js/components/accordion/accordion.js
@@ -7,6 +7,7 @@ import Table from "../table/table.js";
 import { visitPage } from '../../views/view_logic.js';
 
 function redirectForEdit(){
+    // action taken when user clicks on any of the edit buttons in the accordion
     const row = document.querySelector(`.active-editing`);
     const table = row.parentElement;
     const section = table.closest('.summary-container');
@@ -17,10 +18,14 @@ function redirectForEdit(){
     else {
         // Split the string into parts using '-' as the delimiter; retain fund as 1st numeric segment
         const fund = table.id.split('-')[1]
-        
+        // record the fund
         CurrentFund.update(fund);
-        const lineItem = row.querySelector('.line-item').textContent;
+        // record the appropriation and cost center
+        localStorage.setItem('filter-approp', table.id.split('-')[2]);
+        localStorage.setItem('filter-cc', table.id.split('-')[3]);
+
         // visit the correct page for editing
+        const lineItem = row.querySelector('.line-item').textContent;
         switch(lineItem){
             case 'Personnel Expenditures':
                 visitPage('personnel');

--- a/src/js/components/table/subcomponents/buttons.js
+++ b/src/js/components/table/subcomponents/buttons.js
@@ -64,7 +64,7 @@ function initializeConfirmButton(updateCallback){
 }
 
 const Edit = {
-    html: '<button class="btn btn-edit">Edit row</button>',
+    html(text = 'Edit row'){ return `<button class="btn btn-edit">${text}</button>`},
     hide: hideButton('btn-edit'),
     show: showButton('btn-edit'),
     init : function(actionOnClick, updateCallback){
@@ -72,14 +72,8 @@ const Edit = {
     }
 };
 
-const Delete = {
-    html: '<button class="btn btn-delete">Delete</button>',
-    hide: hideButton('btn-delete'),
-    show: showButton('btn-delete')
-};
-
 const Confirm = {
-    html: '<button class="btn btn-confirm">Confirm</button>',
+    html() {return `<button class="btn btn-confirm">Confirm</button>`},
     hide: hideButton('btn-confirm'),
     show: showButton('btn-confirm')
 };
@@ -93,12 +87,10 @@ const AddRow = {
 };
 
 export const Buttons = {
-    Delete: Delete,
     Edit : Edit,
     Confirm : Confirm,
     AddRow : AddRow,
-    edit_confirm_btns : Edit.html + Confirm.html ,
-    all_btns : Delete.html + Edit.html + Confirm.html
+    edit_confirm_btns : Edit.html() + Confirm.html() ,
 }
 
 export default Buttons;

--- a/src/js/components/table/subcomponents/filters.js
+++ b/src/js/components/table/subcomponents/filters.js
@@ -130,6 +130,21 @@ const Filter = {
                 this.resetFilter(filterID);
             }
         });
+    },
+
+    saveFilterValues(){
+        const filters = document.querySelectorAll('.filter-dropdown');
+        filters.forEach((filter) => {
+            localStorage.setItem(filter.id, filter.value);
+        });
+    },
+
+    setFiltersFromStorage(){
+        const filters = document.querySelectorAll('.filter-dropdown');
+        filters.forEach((filter) => {
+            let storedValue = localStorage.getItem(filter.id);
+            filter.value = storedValue;
+        });
     }
 }
 

--- a/src/js/components/table/subcomponents/filters.js
+++ b/src/js/components/table/subcomponents/filters.js
@@ -105,8 +105,6 @@ const Filter = {
     },
     
     resetAllFilters() {
-        console.log('reseting');
-        console.trace();
         const filters = document.querySelectorAll('.filter-dropdown');
         filters.forEach((filter) => {
             filter.value = '';

--- a/src/js/components/table/subcomponents/filters.js
+++ b/src/js/components/table/subcomponents/filters.js
@@ -106,6 +106,7 @@ const Filter = {
     
     resetAllFilters() {
         console.log('reseting');
+        console.trace();
         const filters = document.querySelectorAll('.filter-dropdown');
         filters.forEach((filter) => {
             filter.value = '';

--- a/src/js/components/table/subcomponents/filters.js
+++ b/src/js/components/table/subcomponents/filters.js
@@ -100,12 +100,20 @@ const Filter = {
         }
     },
 
-    resetFilter(){
-
+    resetFilter(filterClass) {
+        const filterObj = document.querySelector(`#filter-${filterClass}`);
+        if (filterObj) {
+            // Set filter to 'All' option
+            filterObj.value = "All";
+        }
     },
-
-    resetAllFilters(){
-        
+    
+    resetAllFilters() {
+        const filters = document.querySelectorAll('.filter-dropdown');
+        filters.forEach((filter) => {
+            let filterClass = filter.classList[0];
+            this.resetFilter(filterClass);
+        });
     }
 }
 

--- a/src/js/components/table/subcomponents/filters.js
+++ b/src/js/components/table/subcomponents/filters.js
@@ -111,8 +111,20 @@ const Filter = {
     resetAllFilters() {
         const filters = document.querySelectorAll('.filter-dropdown');
         filters.forEach((filter) => {
-            let filterClass = filter.classList[0];
-            this.resetFilter(filterClass);
+            this.resetFilter(filter.id);
+        });
+    },
+
+    resetAfterNewRow(responses) {
+        const filters = document.querySelectorAll('.filter-dropdown');
+        filters.forEach((filter) => {
+            // Get the filter class to tell us what's in the filter
+            let filterID = filter.id.replace('filter-', '');
+            // If the value from the new poistion doesn't match the filter value, 
+            // reset it so that the new position will show up
+            if (filter.value != responses[filterID]){
+                this.resetFilter(filterID);
+            }
         });
     }
 }

--- a/src/js/components/table/subcomponents/filters.js
+++ b/src/js/components/table/subcomponents/filters.js
@@ -92,11 +92,15 @@ const Filter = {
 
     updateOptions(filterClass) {
         const filterObj = document.querySelector(`#filter-${filterClass}`);
+        // save selected value
+        const value = filterObj.value;
         if (filterObj) {
             // Clear all existing options except for the default 'All' option
             filterObj.options.length = 1;
             // Add new options
             this.addAllOptions(filterClass);
+            // correct selection
+            filterObj.value = value;
         }
     },
 

--- a/src/js/components/table/subcomponents/filters.js
+++ b/src/js/components/table/subcomponents/filters.js
@@ -65,6 +65,8 @@ const Filter = {
             filterSettings[filterClass] = event.target.value;
             // Apply all filters
             filterData();
+            // save filter value
+            this.saveFilterValues();
         });
     },
 
@@ -92,30 +94,22 @@ const Filter = {
 
     updateOptions(filterClass) {
         const filterObj = document.querySelector(`#filter-${filterClass}`);
-        // save selected value
-        const value = filterObj.value;
         if (filterObj) {
             // Clear all existing options except for the default 'All' option
             filterObj.options.length = 1;
             // Add new options
             this.addAllOptions(filterClass);
-            // correct selection
-            filterObj.value = value;
         }
-    },
-
-    resetFilter(filterClass) {
-        const filterObj = document.querySelector(`#filter-${filterClass}`);
-        if (filterObj) {
-            // Set filter to 'All' option
-            filterObj.value = "All";
-        }
+        // update selection to match saved values
+        this.setFiltersFromStorage();
     },
     
     resetAllFilters() {
+        console.log('reseting');
         const filters = document.querySelectorAll('.filter-dropdown');
         filters.forEach((filter) => {
-            this.resetFilter(filter.id);
+            filter.value = '';
+            localStorage.setItem(filter.id, '');
         });
     },
 
@@ -142,7 +136,10 @@ const Filter = {
     setFiltersFromStorage(){
         const filters = document.querySelectorAll('.filter-dropdown');
         filters.forEach((filter) => {
+            // get the stored value for the filter and apply it
             let storedValue = localStorage.getItem(filter.id);
+            // if the filter has never been used, default to "All"
+            if (!storedValue) { storedValue = '' };
             filter.value = storedValue;
         });
     }

--- a/src/js/components/table/subcomponents/filters.js
+++ b/src/js/components/table/subcomponents/filters.js
@@ -1,15 +1,8 @@
 // Helper functions & constants
 
-// object to hold all current filter statuses
-const filterSettings = {
-    'approp-name': '',
-    'cc-name': '',
-    'object-name': '',
-    'object-category': ''
-};
-
 // helper function to filter data based on all filters
 function filterData() {
+    console.log('filtering data')
     // Get all rows in the table
     const rows = document.querySelectorAll('#main-table tbody tr');
     
@@ -17,16 +10,17 @@ function filterData() {
     rows.forEach(row => {
         let isVisible = true;
         
-        // Check each filter setting against the row's cells
-        for (const [filterId, filterValue] of Object.entries(filterSettings)) {
-            const cell = row.querySelector(`.${filterId}`);
-
+        const filters = document.querySelectorAll('.filter-dropdown');
+        filters.forEach(filter => {
+            // Check each filter setting against the row's cells
+            let filterID = filter.id.replace('filter-', '');
+            const cell = row.querySelector(`.${filterID}`);
+    
             // only show row if values pass through all filters 
-            if (filterValue && cell && (cell.textContent.trim() !== filterValue)) {
+            if (filter.value && cell && (cell.textContent.trim() !== filter.value)) {
                 isVisible = false;
-                break;
-            } 
-        }
+            }
+        });
 
         // Show or hide the row based on visibility
         row.classList.toggle('hidden', !isVisible);
@@ -61,12 +55,10 @@ const Filter = {
         this.addAllOptions(filterClass);
         // Bind change event to the select element
         filterDiv.querySelector('.filter-dropdown').addEventListener('change', event => {
-            // Update filter settings
-            filterSettings[filterClass] = event.target.value;
-            // Apply all filters
-            filterData();
             // save filter value
             this.saveFilterValues();
+            // Apply all filters
+            filterData();
         });
     },
 
@@ -141,6 +133,8 @@ const Filter = {
             if (!storedValue) { storedValue = '' };
             filter.value = storedValue;
         });
+        // actually filter data based on selections
+        filterData();
     }
 }
 

--- a/src/js/components/table/subcomponents/filters.js
+++ b/src/js/components/table/subcomponents/filters.js
@@ -98,6 +98,14 @@ const Filter = {
             // Add new options
             this.addAllOptions(filterClass);
         }
+    },
+
+    resetFilter(){
+
+    },
+
+    resetAllFilters(){
+        
     }
 }
 

--- a/src/js/components/table/subcomponents/rows.js
+++ b/src/js/components/table/subcomponents/rows.js
@@ -71,11 +71,8 @@ function saveRowEdits(row){
 }
 
 function markNewRow(){
-    // Get the table element by its ID
-    const table = document.getElementById('main-table');
-    // add a new-row class to the top row
-    let tbody = table.querySelector('tbody');
-    let first_row = tbody.firstChild;
+    // Get the table element by its ID and fetch first row
+    let first_row = document.querySelector('#main-table tbody').firstChild;
     // get the right color from the root() defined in common.css
     const rootStyle = getComputedStyle(document.documentElement);
     const palegreen = rootStyle.getPropertyValue('--palegreen').trim();

--- a/src/js/components/table/subcomponents/rows.js
+++ b/src/js/components/table/subcomponents/rows.js
@@ -32,9 +32,13 @@ async function addNewRow(data_dictionary, columns = []){
         });
     });
 
-    // Append the new row to the table body
+    // Append the new row to the top of the table body
     let tbody = table.querySelector('tbody');
-    tbody.appendChild(new_row);
+    if (tbody.firstChild) {
+        tbody.insertBefore(new_row, tbody.firstChild);
+    } else {
+        tbody.appendChild(new_row);
+    }
 }
 
 function saveRowEdits(row){
@@ -66,13 +70,23 @@ function saveRowEdits(row){
     })
 }
 
+function markNewRow(){
+    // Get the table element by its ID
+    const table = document.getElementById('main-table');
+    // add a new-row class to the top row
+    let tbody = table.querySelector('tbody');
+    tbody.firstChild.classList.add('new-row');
+
+}
+
 const Rows = {
     add : function(data_dictionary, cols){
-        addNewRow(data_dictionary, cols)
+        addNewRow(data_dictionary, cols);
     },
     saveEdits : function(row){
-        saveRowEdits(row)
-    }
+        saveRowEdits(row);
+    },
+    markNewRow : markNewRow
 }
 
 export default Rows;

--- a/src/js/components/table/subcomponents/rows.js
+++ b/src/js/components/table/subcomponents/rows.js
@@ -75,8 +75,16 @@ function markNewRow(){
     const table = document.getElementById('main-table');
     // add a new-row class to the top row
     let tbody = table.querySelector('tbody');
-    tbody.firstChild.classList.add('new-row');
-
+    let first_row = tbody.firstChild;
+    // get the right color from the root() defined in common.css
+    const rootStyle = getComputedStyle(document.documentElement);
+    const palegreen = rootStyle.getPropertyValue('--palegreen').trim();
+    // make first row (with new row) green
+    first_row.style.backgroundColor = palegreen;
+    // Fade back to default after 0.75 seconds
+    setTimeout(() => {
+        first_row.style.backgroundColor = '';
+    }, 750);
 }
 
 const Rows = {

--- a/src/js/components/table/table.css
+++ b/src/js/components/table/table.css
@@ -26,6 +26,10 @@ tr {
     background-color: white;
 }
 
+.new-row {
+    background-color: var(--palegreen);
+}
+
 tr td {
     border-bottom: 1px solid black;
 }

--- a/src/js/components/table/table.css
+++ b/src/js/components/table/table.css
@@ -24,11 +24,10 @@ th {
 tr {
     border-width: 2px;
     background-color: white;
+    /* Ensures fade when indicating a new row */
+    transition: background-color 0.5s ease;
 }
 
-.new-row {
-    background-color: var(--palegreen);
-}
 
 tr td {
     border-bottom: 1px solid black;

--- a/src/js/models/fund.js
+++ b/src/js/models/fund.js
@@ -94,7 +94,7 @@ export class CostCenter{
 
         for (let table of tables) {
           if (table.length > 0 && table[0]['Cost Center Name']) {
-            return 'Cost Center ' + table[0]['Cost Center Name'];
+            return table[0]['Cost Center Name'];
           }
         }
     
@@ -145,8 +145,8 @@ export class Appropriation {
         const tables = [this.nonpersonnel.table, this.personnel.table, this.overtime.table, this.revenue.table];
 
         for (let table of tables) {
-          if (table.length > 0 && table[0]['Appropriation Name']) {
-            return 'Appropriation ' + table[0]['Appropriation Name'];
+          if (table && table[0]['Appropriation Name']) {
+            return table[0]['Appropriation Name'];
           }
         }
     

--- a/src/js/views/04_personnel.js
+++ b/src/js/views/04_personnel.js
@@ -130,8 +130,6 @@ class PersonnelTable extends ViewTable {
     }
 
     editColumns(responses){
-        // reset filters if relevant to ensure that new job shows up
-        Table.Filter.resetAfterNewRow(responses);
         // Edit responses to fit into table
         responses = super.editColumns(responses);
         // edit inputs from modal

--- a/src/js/views/04_personnel.js
+++ b/src/js/views/04_personnel.js
@@ -130,6 +130,9 @@ class PersonnelTable extends ViewTable {
     }
 
     editColumns(responses){
+        // reset filters to ensure that new job shows up
+        Table.Filter.resetAllFilters();
+        // Edit responses to fit into table
         responses = super.editColumns(responses);
         // edit inputs from modal
         responses['avg-salary'] = unformatCurrency(responses['avg-salary']);

--- a/src/js/views/04_personnel.js
+++ b/src/js/views/04_personnel.js
@@ -130,8 +130,8 @@ class PersonnelTable extends ViewTable {
     }
 
     editColumns(responses){
-        // reset filters to ensure that new job shows up
-        Table.Filter.resetAllFilters();
+        // reset filters if relevant to ensure that new job shows up
+        Table.Filter.resetAfterNewRow(responses);
         // Edit responses to fit into table
         responses = super.editColumns(responses);
         // edit inputs from modal

--- a/src/js/views/view_class.js
+++ b/src/js/views/view_class.js
@@ -113,6 +113,10 @@ export class ViewTable {
         // add any newly created cc or approp to the filters
         this.updateFilters();
 
+        // TODO: move to submit new row
+        // mark new row
+        Table.Rows.markNewRow();
+
     }
 
     async build() {
@@ -301,8 +305,7 @@ export class ViewTable {
             // rebuild table
             this.refreshData();
 
-            // mark new row
-            Table.Rows.markNewRow();
+            
         }
     }
 

--- a/src/js/views/view_class.js
+++ b/src/js/views/view_class.js
@@ -113,10 +113,6 @@ export class ViewTable {
         // add any newly created cc or approp to the filters
         this.updateFilters();
 
-        // TODO: move to submit new row
-        // mark new row
-        Table.Rows.markNewRow();
-
     }
 
     async build() {
@@ -285,7 +281,7 @@ export class ViewTable {
         return responses;
     }
 
-    submitNewRow(event) {
+    async submitNewRow(event) {
         // get answers from form, hide form, show answers in table
         var responses = Form.fetchAllResponses(event);
         
@@ -303,9 +299,10 @@ export class ViewTable {
             Table.save();
             
             // rebuild table
-            this.refreshData();
+            await this.refreshData();
 
-            
+            // mark new row
+            Table.Rows.markNewRow();            
         }
     }
 

--- a/src/js/views/view_class.js
+++ b/src/js/views/view_class.js
@@ -6,6 +6,7 @@ import { Subtitle, Title } from "../components/header/header.js";
 import Table from "../components/table/table.js";
 import Form from "../components/form/form.js";
 import Modal from "../components/modal/modal.js";
+import Filter from "../components/table/subcomponents/filters.js";
 
 import { CurrentPage, AccountString } from '../models/'
 
@@ -56,7 +57,9 @@ export class View {
         if (this.subtitle) { Subtitle.update(this.subtitle) };
     }
 
-    cleanup() { return; }
+    cleanup() { 
+        Filter.resetAllFilters();
+    }
 
 }
 

--- a/src/js/views/view_class.js
+++ b/src/js/views/view_class.js
@@ -300,6 +300,9 @@ export class ViewTable {
             
             // rebuild table
             this.refreshData();
+
+            // mark new row
+            Table.Rows.markNewRow();
         }
     }
 

--- a/src/js/views/view_class.js
+++ b/src/js/views/view_class.js
@@ -249,6 +249,8 @@ export class ViewTable {
     }
 
     editColumns(responses) { 
+         // reset filters if relevant to ensure that new job shows up
+         Table.Filter.resetAfterNewRow(responses);
         // if a new appropriation was entered, fix it
         if (responses['approp']){
             responses['approp-name'] = `${responses['approp']} - New`;

--- a/src/js/views/view_class.js
+++ b/src/js/views/view_class.js
@@ -155,10 +155,10 @@ export class ViewTable {
     updateFilters() {
         // update filters with any new values
         if (this.columns.some(column => column.className === 'approp-name')){
-            Table.Filter.updateOptions('Appropriation', 'approp-name');
+            Table.Filter.updateOptions('approp-name');
         }
         if (this.columns.some(column => column.className === 'cc-name')){
-            Table.Filter.updateOptions('Cost Center', 'cc-name');
+            Table.Filter.updateOptions('cc-name');
         }
         if (this.columns.some(column => column.className === 'object-name')){
             Table.Filter.updateOptions('object-name');


### PR DESCRIPTION
 - Closes #102 
 - Closes #86 
 - Closes #116 
 - Closes #118 
 - Closes #122 

---

## Summary

- Add ability to reset filters
- Reset filters after adding a new position (just the filters that don't match the new position)
- Filters still reset on page reload
- Fixed filter bug with appropriation/cost center filters
- New row will always be added to the top of the table
- New row will highlight in green for ~1 second